### PR TITLE
feat: Generalize course recommendations to learning resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
 
             <div class="bg-white shadow-md rounded-lg">
                 <button class="accordion-button w-full flex justify-between items-center p-5 text-left font-semibold text-gray-700 hover:bg-gray-100 focus:outline-none" aria-expanded="false">
-                    <span>Rekomendasi Kursus</span>
+                    <span>Rekomendasi Sumber Belajar</span>
                     <svg class="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
                 </button>
                 <div id="courseRecommendationsContent" class="accordion-content hidden p-5 border-t border-gray-200">

--- a/js/generateRoadmap.js
+++ b/js/generateRoadmap.js
@@ -19,11 +19,11 @@ async function generateRoadmap(targetCareer) {
 
         1.  **Keterampilan Fondasi (foundation_skills)**: Identifikasi 5-7 keterampilan dasar paling krusial yang harus dikuasai.
         2.  **Keterampilan Lanjutan (advanced_skills)**: Identifikasi 5-7 keterampilan lanjutan atau spesialisasi yang relevan.
-        3.  **Rekomendasi Kursus (course_recommendations)**: Berikan 2-4 rekomendasi kursus yang sangat spesifik untuk beberapa keterampilan kunci (baik fondasi maupun lanjutan). Untuk setiap kursus, sertakan:
-            *   \`skill_related\`: Nama skill yang diajarkan kursus tersebut.
-            *   \`course_name\`: Nama lengkap kursus.
-            *   \`provider\`: Penyedia kursus (misalnya, Coursera, Dicoding, edX, Udemy, freeCodeCamp, dll.).
-            *   \`link\`: URL langsung menuju kursus tersebut. Penting: Tambahkan parameter query '?ref=skillsyncid' di akhir setiap URL.
+        3.  **Rekomendasi Sumber Belajar (learning_resources)**: Berikan 3-5 rekomendasi sumber belajar yang sangat relevan, populer, dan memiliki konten berkualitas untuk beberapa keterampilan kunci (baik fondasi maupun lanjutan). Ini bisa berupa artikel teknis mendalam, tutorial komprehensif di blog atau website edukasi, modul kursus online (jika linknya valid dan langsung ke materi), dokumentasi resmi (misalnya untuk tools atau bahasa pemrograman), video tutorial berkualitas tinggi dari channel terpercaya, atau halaman website komunitas yang aktif dan bermanfaat. Untuk setiap sumber, sertakan:
+            *   \`skill_related\`: Nama skill utama yang dibahas atau dapat ditingkatkan oleh sumber belajar ini.
+            *   \`resource_title\`: Judul yang jelas dan deskriptif dari artikel, video, kursus, halaman dokumentasi, atau sumber tersebut.
+            *   \`source_type\`: Jenis sumber (Contoh: "Artikel Blog", "Kursus Online", "Dokumentasi Resmi", "Video Tutorial", "Forum Komunitas", "Panduan Interaktif", "Website Edukasi").
+            *   \`link\`: URL yang VALID dan LANGSUNG menuju sumber belajar tersebut. Pastikan link ini aktif, relevan, dan mengarah ke konten yang sebenarnya dan substansial. Prioritaskan sumber yang memiliki reputasi baik dan konten yang mendalam. Selalu tambahkan parameter query '?ref=skillsyncid' di akhir setiap URL.
         4.  **Ide Proyek Portofolio (portfolio_projects)**: Usulkan 3-4 ide proyek portofolio yang praktis. Untuk setiap proyek, sertakan:
             *   \`title\`: Judul proyek yang menarik.
             *   \`description\`: Deskripsi singkat proyek, apa yang harus dilakukan, dan keterampilan apa yang akan ditunjukkan.
@@ -37,12 +37,18 @@ async function generateRoadmap(targetCareer) {
         {
           "foundation_skills": ["Skill Fondasi 1", "Skill Fondasi 2"],
           "advanced_skills": ["Skill Lanjutan 1", "Skill Lanjutan 2"],
-          "course_recommendations": [
+          "learning_resources": [
             {
-              "skill_related": "Skill yang Relevan dengan Kursus",
-              "course_name": "Nama Detail Kursus",
-              "provider": "Penyedia Kursus (contoh: Coursera)",
-              "link": "https://contoh.kursus.com/path?ref=skillsyncid"
+              "skill_related": "Contoh: Pemrograman Python Dasar",
+              "resource_title": "Tutorial Python Lengkap untuk Pemula di Situs XYZ",
+              "source_type": "Artikel Blog",
+              "link": "https://xyz.com/artikel/python-pemula?ref=skillsyncid"
+            },
+            {
+              "skill_related": "Contoh: Manajemen Proyek Agile",
+              "resource_title": "Kursus Scrum Fundamental",
+              "source_type": "Kursus Online",
+              "link": "https://platformkursus.com/scrum-fundamental?ref=skillsyncid"
             }
           ],
           "portfolio_projects": [
@@ -60,18 +66,24 @@ async function generateRoadmap(targetCareer) {
         {
           "foundation_skills": ["Python Programming", "Statistics and Probability", "Data Wrangling with Pandas", "Data Visualization with Matplotlib/Seaborn", "SQL Databases", "Basic Machine Learning Concepts"],
           "advanced_skills": ["Deep Learning (TensorFlow/PyTorch)", "Natural Language Processing (NLP)", "Big Data Technologies (Spark, Hadoop)", "Cloud Computing (AWS, GCP, Azure)", "MLOps", "Advanced Statistical Modeling"],
-          "course_recommendations": [
+          "learning_resources": [
             {
               "skill_related": "Python Programming",
-              "course_name": "Python for Everybody Specialization",
-              "provider": "Coursera (University of Michigan)",
+              "resource_title": "Python for Everybody Specialization (Coursera)",
+              "source_type": "Kursus Online",
               "link": "https://www.coursera.org/specializations/python-for-everybody?ref=skillsyncid"
             },
             {
               "skill_related": "Machine Learning",
-              "course_name": "Machine Learning by Andrew Ng",
-              "provider": "Coursera (Stanford University)",
+              "resource_title": "Machine Learning by Andrew Ng (Coursera)",
+              "source_type": "Kursus Online",
               "link": "https://www.coursera.org/learn/machine-learning?ref=skillsyncid"
+            },
+            {
+              "skill_related": "SQL Databases",
+              "resource_title": "SQLBolt - Interactive SQL Tutorial",
+              "source_type": "Panduan Interaktif",
+              "link": "https://sqlbolt.com?ref=skillsyncid"
             }
           ],
           "portfolio_projects": [
@@ -166,31 +178,41 @@ async function generateRoadmap(targetCareer) {
         console.warn("Menggunakan data dummy karena API call ke Gemini tidak diaktifkan.");
         const dummyRoadmap = {
             "foundation_skills": [
-                `Dasar ${targetCareer} 1`,
-                `Dasar ${targetCareer} 2`,
-                "SEO Dasar",
-                "Content Marketing Awal",
-                "Analisis Web Fundamental"
+                `Dasar ${targetCareer}: Konsep Utama`,
+                `Dasar ${targetCareer}: Alat Esensial`,
+                "Pemecahan Masalah Dasar",
+                "Komunikasi Efektif"
             ],
             "advanced_skills": [
-                `Spesialisasi ${targetCareer} 1`,
-                `Spesialisasi ${targetCareer} 2`,
-                "Marketing Automation Lanjutan",
-                "Data Analysis untuk Marketing Expert",
-                "CRO Lanjutan"
+                `Spesialisasi Lanjutan ${targetCareer} A`,
+                `Teknik ${targetCareer} Mendalam B`,
+                "Manajemen Proyek terkait " + targetCareer,
+                "Analisis Data untuk " + targetCareer
             ],
-            "course_recommendations": [
+            "learning_resources": [
                 {
-                    "skill_related": `Dasar ${targetCareer} 1`,
-                    "course_name": `Kursus Lengkap ${targetCareer} untuk Pemula`,
-                    "provider": "Udemy",
-                    "link": `https://www.udemy.com/topic/${targetCareer.toLowerCase().replace(/\s+/g, '-')}/?ref=skillsyncid`
+                    "skill_related": `Dasar ${targetCareer}: Konsep Utama`,
+                    "resource_title": `Pengantar Komprehensif ${targetCareer}`,
+                    "source_type": "Artikel Blog",
+                    "link": `https://contoh.situs.dev/artikel/${targetCareer.toLowerCase().replace(/\s+/g, '-')}-pengantar?ref=skillsyncid`
                 },
                 {
-                    "skill_related": "SEO Dasar",
-                    "course_name": "Google Digital Garage - Fundamentals of Digital Marketing",
-                    "provider": "Google",
-                    "link": "https://learndigital.withgoogle.com/digitalgarage/course/digital-marketing?ref=skillsyncid"
+                    "skill_related": `Dasar ${targetCareer}: Alat Esensial`,
+                    "resource_title": `Tutorial Video: Alat Wajib untuk ${targetCareer}`,
+                    "source_type": "Video Tutorial",
+                    "link": `https://youtube.com/watch?v=contoh&list=${targetCareer.toLowerCase().replace(/\s+/g, '-')}-tools&ref=skillsyncid`
+                },
+                {
+                    "skill_related": "Pemecahan Masalah Dasar",
+                    "resource_title": "Kursus Online: Teknik Problem Solving",
+                    "source_type": "Kursus Online",
+                    "link": "https://platformkursus.com/problem-solving-101?ref=skillsyncid"
+                },
+                {
+                    "skill_related": `Teknik ${targetCareer} Mendalam B`,
+                    "resource_title": `Dokumentasi Resmi: ${targetCareer} Advanced Techniques`,
+                    "source_type": "Dokumentasi Resmi",
+                    "link": `https://docs.contoh-teknologi.com/${targetCareer.toLowerCase().replace(/\s+/g, '-')}/advanced?ref=skillsyncid`
                 }
             ],
             "portfolio_projects": [

--- a/js/main.js
+++ b/js/main.js
@@ -151,8 +151,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (roadmapData.advanced_skills && advancedSkillsContent) {
             renderAdvancedSkills(roadmapData.advanced_skills);
         }
-        if (roadmapData.course_recommendations && courseRecommendationsContent) {
-            renderCourseRecommendations(roadmapData.course_recommendations);
+        if (roadmapData.learning_resources && courseRecommendationsContent) { // Menggunakan courseRecommendationsContent sebagai container
+            renderLearningResources(roadmapData.learning_resources, courseRecommendationsContent);
         }
         if (roadmapData.portfolio_projects && portfolioProjectsContent) {
             renderPortfolioProjects(roadmapData.portfolio_projects);
@@ -183,43 +183,44 @@ document.addEventListener('DOMContentLoaded', () => {
         advancedSkillsContent.appendChild(ul);
     }
 
-    function renderCourseRecommendations(courses) {
-        if (!courseRecommendationsContent || !courses || courses.length === 0) return;
-        const gridContainer = document.createElement('div');
-        gridContainer.className = 'grid md:grid-cols-2 lg:grid-cols-3 gap-6';
+    function renderLearningResources(resources, containerElement) {
+        if (!containerElement || !resources || resources.length === 0) return;
 
-        courses.forEach(course => {
+        const resourceListContainer = document.createElement('div');
+        resourceListContainer.className = 'space-y-4'; // Menggunakan space-y untuk jarak antar item
+
+        resources.forEach(resource => {
             const card = document.createElement('div');
-            card.className = 'border p-4 rounded-lg bg-gray-50 shadow-sm';
+            card.className = 'p-4 border rounded-lg bg-gray-50 shadow-sm';
 
-            let logoHtml = '';
-            if (course.provider && course.provider.toLowerCase().includes('google')) {
-                logoHtml = `<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/80px-Google_2015_logo.svg.png" alt="Google" class="course-logo">`;
-            } else if (course.provider && course.provider.toLowerCase().includes('coursera')) {
-                logoHtml = `<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/97/Coursera-Logo_600x600.svg/80px-Coursera-Logo_600x600.svg.png" alt="Coursera" class="course-logo">`;
-            } else if (course.provider && course.provider.toLowerCase().includes('udemy')) {
-                logoHtml = `<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e3/Udemy_logo.svg/80px-Udemy_logo.svg.png" alt="Udemy" class="course-logo">`;
-            } else if (course.provider && course.provider.toLowerCase().includes('dicoding')) {
-                logoHtml = `<img src="https://dicoding-web-img.sgp1.cdn.digitaloceanspaces.com/original/commons/new-dicoding-logo.png" alt="Dicoding" class="course-logo">`;
-            } else {
-                // Placeholder logo jika tidak ada atau tidak dikenal
-                logoHtml = `<span class="course-logo bg-gray-300 rounded-full flex items-center justify-center text-xs text-gray-600 font-semibold">${course.provider ? course.provider.substring(0, 3).toUpperCase() : 'CRS'}</span>`;
-            }
+            // Membuat elemen secara programatik untuk keamanan dan fleksibilitas
+            const titleElement = document.createElement('h4');
+            titleElement.className = 'font-semibold text-gray-700 text-lg mb-1';
+            titleElement.textContent = resource.resource_title;
 
-            card.innerHTML = `
-                <div class="flex items-center mb-2">
-                    ${logoHtml}
-                    <h4 class="font-semibold text-gray-700 flex-1">${course.course_name}</h4>
-                </div>
-                <p class="text-sm text-gray-500 mb-1">Keterampilan: ${course.skill_related || 'Tidak spesifik'}</p>
-                <p class="text-sm text-gray-500 mb-3">Penyedia: ${course.provider}</p>
-                <a href="${course.link}" target="_blank" rel="noopener noreferrer" class="inline-block px-4 py-2 bg-indigo-600 text-white text-sm rounded-md hover:bg-indigo-700 transition duration-300">
-                    Lihat Kursus
-                </a>
-            `;
-            gridContainer.appendChild(card);
+            const typeElement = document.createElement('p');
+            typeElement.className = 'text-xs text-indigo-600 bg-indigo-100 inline-block px-2 py-0.5 rounded-full mb-2 font-medium';
+            typeElement.textContent = resource.source_type;
+
+            const skillElement = document.createElement('p');
+            skillElement.className = 'text-sm text-gray-500 mb-1';
+            skillElement.innerHTML = `Keterampilan Terkait: <span class="font-medium text-gray-600">${resource.skill_related || 'Tidak spesifik'}</span>`;
+
+            const linkElement = document.createElement('a');
+            linkElement.href = resource.link;
+            linkElement.target = '_blank';
+            linkElement.rel = 'noopener noreferrer';
+            linkElement.className = 'inline-block mt-2 px-4 py-2 bg-indigo-600 text-white text-sm rounded-md hover:bg-indigo-700 transition duration-300';
+            linkElement.textContent = 'Kunjungi Sumber';
+
+            card.appendChild(titleElement);
+            card.appendChild(typeElement);
+            card.appendChild(skillElement);
+            card.appendChild(linkElement);
+
+            resourceListContainer.appendChild(card);
         });
-        courseRecommendationsContent.appendChild(gridContainer);
+        containerElement.appendChild(resourceListContainer);
     }
 
     function renderPortfolioProjects(projects) {


### PR DESCRIPTION
This commit refactors the 'Course Recommendations' feature to a more general 'Learning Resources' section.

Key changes:
- In `js/generateRoadmap.js`:
    - The prompt to the AI has been updated to request diverse 'learning_resources' (articles, tutorials, courses, docs, videos) instead of just 'course_recommendations'.
    - The expected JSON schema now includes `learning_resources` with fields: `skill_related`, `resource_title`, `source_type`, and `link`.
    - Dummy data has been updated to reflect the new `learning_resources` schema.
- In `index.html`:
    - The accordion button label changed from "Rekomendasi Kursus" to "Rekomendasi Sumber Belajar".
- In `js/main.js`:
    - The rendering function `renderCourseRecommendations` was renamed to `renderLearningResources`.
    - The logic within `renderLearningResources` was updated to dynamically create and display learning resource items, showing the resource title, source type (as a tag), related skill, and a link to the resource.
    - The card design for resources is now more generic to accommodate various types of learning materials.

This change aims to improve the relevance and validity of the links provided by the AI by broadening the scope of recommended content.