### PR TITLE
Fix: Atasi ReferenceError untuk html2canvas saat unduh PDF

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,8 +230,8 @@
         </footer>
     </div>
 
-    <script type="module" src="js/main.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" integrity="sha512-BNaRQnYJYiPSqHHDb58B0yaPfCu+Wgds8Gp/gU33kqBtgNS4tSPHuGibyoVXM5RdhCRKOk5BWdJCOxSKagD8LQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-qZvrmS2ekKPF2mSznTQsxqPgnpkI4DNTlrdUmTzrDgektczlKNRRhy5X5AAOnx5S09ydFYWWNSfcEqDTTHgtNA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -377,7 +377,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
                 const { jsPDF } = window.jspdf; // Ambil jsPDF dari global window object
-                const pdf = new jsPDF({
+                const pdf = new jsPDF({ // Ini sudah benar menggunakan window.jspdf.jsPDF secara implisit
                     orientation: 'p',
                     unit: 'pt',
                     format: 'a4',
@@ -393,7 +393,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
 
                 // Menggunakan html2canvas untuk merender elemen ke canvas
-                const canvas = await html2canvas(contentToPrint, {
+                const canvas = await window.html2canvas(contentToPrint, { // Menggunakan window.html2canvas
                     scale: 2, // Tingkatkan skala untuk kualitas yang lebih baik
                     useCORS: true, // Jika ada gambar dari domain lain
                     logging: false, // Matikan logging html2canvas di console


### PR DESCRIPTION
- Mengubah pemanggilan html2canvas menjadi window.html2canvas untuk memastikan akses ke global scope.
- Memperbaiki urutan pemuatan skrip di index.html agar library CDN (html2canvas, jspdf) dimuat sebelum main.js.

Perubahan ini bertujuan untuk mengatasi masalah 'html2canvas is not defined' saat mencoba mengunduh peta jalan sebagai PDF.